### PR TITLE
BT - Try extended information on bind query

### DIFF
--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -917,6 +917,7 @@ private:
 	joytype_t mapVIDPIDtoJoystickType(uint16_t idVendor, uint16_t idProduct, bool exclude_hid_devices);
 	bool transmitPS4UserFeedbackMsg();
 	bool transmitPS3UserFeedbackMsg();
+	bool mapNameToJoystickType(const uint8_t *remoteName);
 
 	bool anychange = false;
 	volatile bool joystickEvent = false;
@@ -1692,12 +1693,15 @@ private:
 	void inline sendHCIReadBDAddr();
 	void inline sendHCIReadLocalVersionInfo();
 	void inline sendHCIWriteScanEnable(uint8_t scan_op);
+	void inline sendHCIHCIWriteInquiryMode(uint8_t inquiry_mode);
+	void inline sendHCISetEventMask();
 
 	void inline sendHCIRemoteNameRequest();
 	void inline sendHCIRemoteVersionInfoRequest();
 	void handle_hci_command_complete();
 	void handle_hci_command_status();
 	void handle_hci_inquiry_result();
+	void handle_hci_extended_inquiry_result();
 	void handle_hci_inquiry_complete();
 	void handle_hci_incoming_connect();
 	void handle_hci_connection_complete();

--- a/examples/JoystickBT/helperPS.ino
+++ b/examples/JoystickBT/helperPS.ino
@@ -22,7 +22,7 @@ void printAngles(){
 void getCoords(uint16_t &xc, uint16_t &yc, uint8_t &isTouch){
 
 	//uint8_t finger = 0;  //only getting finger 1
-	uint8_t Id = 0;
+	//uint8_t Id = 0;
 
 
   // Trackpad touch 1: id, active, x, y


### PR DESCRIPTION
Trying out using the extended Inquiry data search instead of the real simple one.  This allows us to hopefully get the name of the device as part of this, which now allows the PS4 to know it is a PS4 on the Pair type constructor.

Still WIP to understand XBox one...